### PR TITLE
Potential fix for code scanning alert no. 112: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/anthnyajp/SecureHTTP_ResponseHeaderCheck/security/code-scanning/112](https://github.com/anthnyajp/SecureHTTP_ResponseHeaderCheck/security/code-scanning/112)

To fix the problem, we should add a `permissions` block to the workflow to limit the [GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) privileges according to the least privilege principle. Since this workflow only analyses Python code using Pylint (and does not appear to need write or deploy privileges), setting `contents: read` at the workflow or job level is appropriate. The cleanest way is to add the `permissions: contents: read` block at the root level, just below the `name` and before the `on` statement, to apply it to all jobs within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
